### PR TITLE
Add a stack.yaml to enable building everything with stack (and potentially without nix)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,15 @@
+resolver: lts-18.28
+
+packages:
+- .
+
+extra-deps:
+- git: https://github.com/EmaApps/ema.git 
+  commit: a1c7932c99d8f8e4e3689278558c67429b1369a1
+- lvar-0.1.0.0@sha256:e901135387866b01deac6a643498682a5692bb2b59089b66bd2142018160908b,1298
+- monad-logger-extras-0.1.1.1@sha256:60f74705d7f2f2bec317adc9ac997b4a0915c155d3ffcd103a24f0b0d38ffaf1,1606
+- unionmount-0.2.0.0@sha256:75e962ee8b9d9e0a57c2742a831856c691e305acb5e4e1aed6850fe131b2eb9d,1481
+- url-slug-0.1.0.0@sha256:a3882512dab36f71d556eabe26fcd99483819e56a3e1f3b58183c9041203d402,1956
+- relude-1.1.0.0@sha256:fe82b67d4560b9eff8d7dd12c5e1f786b25d52d64f7302ad82a3bbec9a0bd55e,11747
+
+system-ghc: true


### PR DESCRIPTION
More support for non-nix workflows.

I added the multisite branch of ema as a dependency, and added dependencies suggested by stack. I verified that this gets the code compiling with just stack without nix - just run `stack build`.

Other notes: Running the generated binary seems to run the ema server, but I can't see the hot code reload working. Probably requires some other stuff to be installed.