### PR TITLE
Add jobs.csv, render it in /jobs; hot reload supported

### DIFF
--- a/fpindia-site.cabal
+++ b/fpindia-site.cabal
@@ -27,6 +27,7 @@ executable fpindia-site
     , base
     , blaze-html
     , blaze-markup
+    , cassava
     , containers
     , data-default
     , directory
@@ -96,6 +97,7 @@ executable fpindia-site
 
   main-is:            Main.hs
   other-modules:
+    FPIndia.Jobs
     FPIndia.Model
     FPIndia.Route
     FPIndia.Site

--- a/jobs/jobs.csv
+++ b/jobs/jobs.csv
@@ -1,0 +1,3 @@
+name,location
+Juspay,Bangalore
+ByteAlly,Chennai

--- a/src/FPIndia/Jobs.hs
+++ b/src/FPIndia/Jobs.hs
@@ -1,0 +1,46 @@
+module FPIndia.Jobs (
+  Job (..),
+  jobsDynamic,
+) where
+
+import Control.Exception (throw)
+import Control.Monad.Logger
+import Data.Csv (FromNamedRecord (..), (.:))
+import Data.Csv qualified as Csv
+import Ema (Dynamic (Dynamic))
+import GHC.IO.Exception (userError)
+import System.FilePath (takeDirectory, takeFileName, (</>))
+import System.UnionMount qualified as UM
+import UnliftIO
+
+data Job = Job
+  { jobName :: !Text
+  , jobLocation :: !Text
+  }
+  deriving stock (Eq, Show)
+
+instance FromNamedRecord Job where
+  parseNamedRecord r = Job <$> r .: "name" <*> r .: "location"
+
+jobsDynamic ::
+  forall m.
+  (MonadIO m, MonadUnliftIO m, MonadLogger m, MonadLoggerIO m) =>
+  FilePath ->
+  m (Dynamic m [Job])
+jobsDynamic path = do
+  let (baseDir, jobsFile) = takeDirectory &&& takeFileName $ path
+      pats = [((), jobsFile)]
+  Dynamic <$> UM.mount baseDir pats mempty mempty (const $ handleUpdate baseDir)
+  where
+    handleUpdate :: FilePath -> FilePath -> UM.FileAction () -> m ([Job] -> [Job])
+    handleUpdate baseDir fp = \case
+      UM.Refresh _ _ -> do
+        let jobsFile = baseDir </> fp
+        logInfoNS "Jobs" $ "Loading jobs from " <> toText jobsFile
+        s <- readFileLBS jobsFile
+        case Csv.decodeByName @Job s of
+          Left err -> throw $ userError $ "Failed to decode CSV file " <> jobsFile <> ": " <> err
+          Right (_, toList -> rows) -> pure $ const rows
+      UM.Delete -> do
+        logInfoNS "Jobs" $ "Deloading all jobs; file got deleted: " <> toText fp
+        pure $ const mempty

--- a/src/FPIndia/Model.hs
+++ b/src/FPIndia/Model.hs
@@ -2,9 +2,11 @@ module FPIndia.Model where
 
 import Ema.Route.Lib.Extra.MarkdownRoute qualified as MR
 import Ema.Route.Lib.Extra.StaticRoute qualified as SR
+import FPIndia.Jobs (Job)
 
 data Model = Model
   { modelStatic :: SR.Model
   , modelMarkdown :: MR.Model
+  , modelJobs :: [Job]
   }
   deriving stock (Show, Generic)

--- a/src/FPIndia/Site.hs
+++ b/src/FPIndia/Site.hs
@@ -7,6 +7,7 @@ import Data.Default (def)
 import Data.Generics.Sum.Any (AsAny (_As))
 import Ema
 import Ema.Route.Lib.Extra.MarkdownRoute qualified as MR
+import FPIndia.Jobs qualified as Jobs
 import FPIndia.Model (Model (Model, modelStatic))
 import FPIndia.Route (Route (..), StaticRoute)
 import FPIndia.View (renderHtmlRoute)
@@ -16,7 +17,8 @@ instance EmaSite Route where
   siteInput cliAct () = do
     staticRouteDyn <- siteInput @StaticRoute cliAct ()
     markdownDyn <- siteInput @MR.MarkdownRoute cliAct $ def {MR.argBaseDir = "markdown"}
-    pure $ Model <$> staticRouteDyn <*> markdownDyn
+    jobsDyn <- Jobs.jobsDynamic "jobs/jobs.csv"
+    pure $ Model <$> staticRouteDyn <*> markdownDyn <*> jobsDyn
   siteOutput rp m = \case
     Route_Html r ->
       Ema.AssetGenerated Ema.Html $ renderHtmlRoute rp m r

--- a/src/FPIndia/View.hs
+++ b/src/FPIndia/View.hs
@@ -2,7 +2,8 @@
 
 module FPIndia.View where
 
-import FPIndia.Model (Model)
+import FPIndia.Jobs qualified as Jobs
+import FPIndia.Model (Model (modelJobs))
 import FPIndia.Route (HtmlRoute (..), Route)
 import FPIndia.View.Util (renderMarkdown, routeHref, routeTitle, staticRouteUrl)
 import Optics.Core (Prism')
@@ -39,6 +40,14 @@ renderBody rp model r = do
       HtmlRoute_ConnectWithUs -> do
         renderMarkdown model "connect.md"
       HtmlRoute_FpJobsInIndia -> do
+        H.div ! A.class_ "my-8" $ do
+          H.header "Current Jobs"
+          forM_ (modelJobs model) $ \job ->
+            H.li $ do
+              H.b $ H.toHtml $ Jobs.jobName job
+              " - "
+              H.em $ H.toHtml $ Jobs.jobLocation job
+        H.header "About"
         renderMarkdown model "jobs.md"
       HtmlRoute_Resources -> do
         renderMarkdown model "resources.md"

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1100,6 +1100,21 @@ select {
   margin-right: auto;
 }
 
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
 .mt-8 {
   margin-top: 2rem;
 }


### PR DESCRIPTION
This PR initializes the basic infrastructure needed to do #10 

- A simple `jobs.csv` is added, along with a simple Haskell type
- An Ema `Dynamic` is produced by `jobsDynamic` - which returns `[Job]` as `jobs.csv` changes (the mechanism behind hot-reload)
