### PR TITLE
nix: Upgrade haskell-flake/flake-parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Install Nix, enable Flakes (see below) and then run `bin/run` to get the site up
 
 To develop with full IDE support in Visual Studio Code, follow these steps:
 
-- [Install Nix](https://nixos.org/download.html) & [enable Flakes](https://nixos.wiki/wiki/Flakes)
-- Run `nix develop -c haskell-language-server` to sanity check your environment 
+- [Install Nix](https://zero-to-flakes.com/install/)
+- Run `nix develop -c haskell-language-server` to sanity check your environment
 - Open the repository [as single-folder workspace](https://code.visualstudio.com/docs/editor/workspaces#_singlefolder-workspaces) in Visual Studio Code
     - Install the recommended extensions
     - <kbd>Ctrl+Shift+P</kbd> to run the command "Nix-Env: Select Environment" and select `shell.nix`. The extension will ask you to reload VSCode at the end.
 - Press <kbd>Ctrl+Shift+B</kbd> in VSCode, or run `bin/run` in terminal, to launch the Ema dev server, and navigate to http://localhost:8081/
 
-All but the final step need to be done only once. Check [the Ema tutorial](https://ema.srid.ca/start/tutorial) next.
+All but the final step need to be done only once. Check [the Ema tutorial](https://ema.srid.ca/tutorial) next.
 
 ## Note
 
@@ -24,11 +24,11 @@ All but the final step need to be done only once. Check [the Ema tutorial](https
 - Configuration:
   - To change the port (or the Ema CLI arguments, used by `bin/run`), see `./.ghcid` (if you leave out `--port` a random port will be used)
   - To update Ema to the latest Git revision, run `nix flake lock --update-input ema` or just `nix flake update` (the latter updates all Nix inputs)
-    - Be sure to check https://ema.srid.ca/guide/upgrade for changes needed.
-  - To add/remove Haskell dependencies, see the .cabal file. If a dependency is unavailable in nixpkgs, you can override it (to point to say a Git repo) in the `source-overrides` (or `overrides` if you need more power) attribute of flake.nix. You can imitate the manner in which the `ema` package itself is overridden.
+    - Be sure to check https://ema.srid.ca/start/upgrade for changes needed.
+  - To add/remove Haskell dependencies, see https://zero-to-flakes.com/haskell-flake/dependency/
 - To generate the site, run:
   ```sh
-  mkdir /tmp/site 
+  mkdir /tmp/site
   nix run . -- gen /tmp/site
   ```
   - You might want to change or remove the `<base>` tag in `Main.hs` depending on where you will be deploying the site.

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1668450977,
-        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1668167720,
-        "narHash": "sha256-5wDTR6xt9BB3BjgKR+YOjOkZgMyDXKaX79g42sStzDU=",
+        "lastModified": 1700089378,
+        "narHash": "sha256-zckZj26XDiizXN4VSMzYa/uEGRg6FsRIUdHDy0OtogU=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "4fc511d93a55fedf815c1647ad146c26d7a2054e",
+        "rev": "3694fec07c99d3598fced7dfbaebe6a7fb10e4b7",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,5 @@
+# This is a modular Nix flake
+# Learn about it here: https://zero-to-flakes.com/
 {
   description = "Ema template app";
   inputs = {
@@ -5,17 +7,16 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
   };
-  outputs = { self, nixpkgs, flake-parts, haskell-flake, ... }:
-    flake-parts.lib.mkFlake { inherit self; } {
+  outputs = inputs@{ self, nixpkgs, flake-parts, haskell-flake, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         haskell-flake.flakeModule
       ];
-      perSystem = { self', config, inputs', pkgs, lib, ... }: {
+      perSystem = { self', inputs', pkgs, lib, ... }: {
         # "haskellProjects" comes from https://github.com/srid/haskell-flake
         haskellProjects.default = {
-          packages.fpindia-site.root = ./.;
-          buildTools = hp: {
+          devShell.tools = hp: {
             inherit (pkgs)
               treefmt
               nixpkgs-fmt
@@ -26,9 +27,10 @@
               fourmolu
               tailwind;
           };
-          overrides = self: super: { };
+          # Want to override Haskell dependencies?
+          # See https://zero-to-flakes.com/haskell-flake/dependency
         };
-        packages.default = config.packages.fpindia-site;
+        packages.default = self'.packages.fpindia-site;
         apps.tailwind-run.program = "${lib.getExe pkgs.haskellPackages.tailwind}";
       };
     };

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,1 @@
-# TODO: Remove this after https://github.com/srid/haskell-template/issues/23
-
-(import
-  (
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/b4a34015c698c7793d592d66adbab377907a2be8.tar.gz";
-      sha256 = "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=";
-    }
-  )
-  {
-    src = ./.;
-  }).shellNix
+(builtins.getFlake ("git+file://" + toString ./.)).devShells.${builtins.currentSystem}.default


### PR DESCRIPTION
Just a periodic Nix maintenance. See commit messages for details.

The main benefit is that we now use newer `haskell-flake` which gives us a more ergonomic way to override Haskell dependencies in Nix: https://zero-to-flakes.com/haskell-flake/dependency/